### PR TITLE
feat: Implement NLU confidence scores and refactor output structure

### DIFF
--- a/services/brain/language_center/nlu/tests/test_gemini_nlu_service.py
+++ b/services/brain/language_center/nlu/tests/test_gemini_nlu_service.py
@@ -8,6 +8,9 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+# Import 'types' to be able to assert against types.GenerateContentConfig
+from google.genai import types
+
 from services.brain.language_center.nlu.src.gemini_nlu_service import (
     GeminiNLUService,
 )
@@ -19,12 +22,11 @@ from services.brain.language_center.nlu.src.nlu_service_interface import (
 @pytest.fixture
 def mock_genai_client():
     """Mock google.genai.Client & models.generate_content method."""
-    # FIX: Corrected patch path to reflect 'from google import genai'
     with patch("google.genai.Client") as mock_client_cls:
-        # Configure the return_value (the mock instance) and its
-        # methods/attributes
         mock_client = mock_client_cls.return_value
-        mock_client.models.generate_content.return_value = Mock()
+        # Ensure generate_content is a mock so we can set its return value
+        # and check calls
+        mock_client.models.generate_content = Mock()
         yield mock_client
 
 
@@ -35,7 +37,10 @@ def gemini_nlu_service(mock_genai_client):
     Ensures GOOGLE_API_KEY is set for initialization.
     """
     os.environ["GOOGLE_API_KEY"] = "dummy_api_key_for_test"
-    service = GeminiNLUService(mock_genai_client)
+    # When initializing GeminiNLUService, it creates its own genai.Client().
+    # The fixture mocks genai.Client, so the instance created inside
+    # GeminiNLUService will be the mock_client controlled by the fixture.
+    service = GeminiNLUService(model_name="gemini-1.5-flash")
     yield service
     del os.environ["GOOGLE_API_KEY"]
 
@@ -46,21 +51,121 @@ def test_gemini_nlu_service_implements_interface():
 
 
 def test_process_nlu_successful(gemini_nlu_service, mock_genai_client):
-    """Tests successful NLU processing by GeminiNLUService.
+    """Tests successful NLU processing for a known intent.
 
-    Mocks a valid JSON response from Gemini.
+    Mocks a valid JSON response from Gemini, including confidence.
     """
     test_text = "What is the weather in Paris?"
-    expected_response_text = json.dumps(
+    gemini_raw_response = json.dumps(
         {"intent": "get_weather", "entities": {"location": "Paris"}}
     )
-    mock_genai_client.models.generate_content.return_value.text = expected_response_text
+    mock_genai_client.models.generate_content.return_value.text = gemini_raw_response
 
     result = gemini_nlu_service.process_nlu(test_text)
 
-    # Assert that the generate_content method was called with the expected prompt
-    # FIX: Access the prompt string from the 'kwargs' dictionary
+    # Assert generate_content was called with correct prompt and config
+    mock_genai_client.models.generate_content.assert_called_once()
     call_kwargs = mock_genai_client.models.generate_content.call_args.kwargs
-    # The 'contents' argument is a list, and the first element is the prompt string
+    # The 'contents' argument is a list, and the first element is the prompt
+    # string
     assert f"User Input: {test_text}" in call_kwargs["contents"][0]
-    assert result == {"intent": "get_weather", "entities": {"location": "Paris"}}
+    assert isinstance(call_kwargs["config"], types.GenerateContentConfig)
+    assert call_kwargs["config"].response_mime_type == "application/json"
+    assert call_kwargs["config"].temperature == 0.0
+
+    # Assert the returned NLU result structure, including confidence and
+    # original_text
+    expected_result = {
+        "intent": {"name": "get_weather", "confidence": 0.95},
+        "entities": {"location": "Paris"},
+        "original_text": test_text,
+    }
+    assert result == expected_result
+
+
+def test_process_nlu_unknown_intent(gemini_nlu_service, mock_genai_client):
+    """Tests NLU processing for an unknown intent.
+
+    Mocks an "unknown" JSON response from Gemini.
+    """
+    test_text = "Random gibberish that makes no sense."
+    gemini_raw_response = json.dumps(
+        {"intent": "unknown", "entities": {"raw_query": test_text}}
+    )
+    mock_genai_client.models.generate_content.return_value.text = gemini_raw_response
+
+    result = gemini_nlu_service.process_nlu(test_text)
+
+    # Assert generate_content call (same config as above)
+    mock_genai_client.models.generate_content.assert_called_once()
+    call_kwargs = mock_genai_client.models.generate_content.call_args.kwargs
+    assert f"User Input: {test_text}" in call_kwargs["contents"][0]
+    assert isinstance(call_kwargs["config"], types.GenerateContentConfig)
+    assert call_kwargs["config"].response_mime_type == "application/json"
+    assert call_kwargs["config"].temperature == 0.0
+
+    # Assert the returned NLU result structure for unknown intent
+    expected_result = {
+        "intent": {
+            "name": gemini_nlu_service.UNKNOWN_INTENT_NAME,
+            "confidence": 0.2,
+        },
+        "entities": {"raw_query": test_text},
+        "original_text": test_text,
+    }
+    assert result == expected_result
+
+
+def test_process_nlu_json_decode_error(gemini_nlu_service, mock_genai_client):
+    """Tests NLU processing when Gemini returns malformed JSON."""
+    test_text = "This response is not JSON"
+    # Simulate a non-JSON response that would cause json.loads to fail
+    mock_genai_client.models.generate_content.return_value.text = test_text
+
+    result = gemini_nlu_service.process_nlu(test_text)
+
+    # Assert generate_content was called
+    mock_genai_client.models.generate_content.assert_called_once()
+
+    # Assert the returned NLU result structure for JSON decode error
+    expected_result = {
+        "intent": {
+            "name": gemini_nlu_service.UNKNOWN_INTENT_NAME,
+            "confidence": 0.0,
+        },
+        "entities": {},
+        "original_text": test_text,
+    }
+    assert result == expected_result
+
+
+def test_process_nlu_empty_gemini_response(gemini_nlu_service, mock_genai_client):
+    """Tests NLU processing when Gemini returns an empty response (None)."""
+    from services.input_processor.src.input_processor import NLUProcessingError
+
+    test_text = "Empty response scenario"
+    mock_genai_client.models.generate_content.return_value.text = None
+
+    with pytest.raises(NLUProcessingError) as excinfo:
+        gemini_nlu_service.process_nlu(test_text)
+
+    # Assert generate_content was called
+    mock_genai_client.models.generate_content.assert_called_once()
+
+    assert "Gemini API returned an empty response (None)." in str(excinfo.value)
+
+
+def test_process_nlu_api_error(gemini_nlu_service, mock_genai_client):
+    """Tests NLU processing when Gemini API call itself fails (raises Exception)."""
+    from services.input_processor.src.input_processor import NLUProcessingError
+
+    test_text = "API error scenario"
+    mock_genai_client.models.generate_content.side_effect = Exception("API call failed")
+
+    with pytest.raises(NLUProcessingError) as excinfo:
+        gemini_nlu_service.process_nlu(test_text)
+
+    # Assert generate_content was called
+    mock_genai_client.models.generate_content.assert_called_once()
+
+    assert "Gemini API call failed: API call failed" in str(excinfo.value)


### PR DESCRIPTION
## ✨ Type of Change

Please check the type of change your PR introduces:

- [x] New feature
- [x] Bug fix
- [x] Refactor/Code cleanup
- [ ] Documentation update
- [ ] Build/CI/CD related change
- [ ] Chore (e.g., dependency updates, configs)
- [ ] Other (please describe below)

---

## 📝 Description

This PR introduces **confidence scores** into the NLU output, aligning the `GeminiNLUService` with the `brain:language_center`'s expected API contract (`{"intent": {"name": "greet", "confidence": 0.95}}`). Previously, the NLU output lacked this crucial signal, limiting downstream dialogue management and decision-making for ambiguous or low-confidence user inputs.

The core solution involves modifying the `GeminiNLUService.process_nlu` method to dynamically calculate and include a simulated confidence score based on the identified intent. This provides the `language_center` and other components with valuable information for handling various user inputs more gracefully.

Additionally, this PR addresses several **MyPy type-checking errors** and **Ruff style/linting violations** that emerged during development, ensuring the codebase remains clean, consistent, and adheres to quality standards.

---

## 🔗 Related Issues

Link to the GitHub issue(s) this PR addresses. Use keywords like `Closes #`, `Fixes #`, or `Resolves #` to automatically close the issue(s) when the PR is merged.

- Closes #15 
- Resolves #15 

---

## 💡 Changes Made

* **`GeminiNLUService.process_nlu` Modification:**
    * The method now returns an `intent` dictionary with `{"name": str, "confidence": float}`.
    * A **simulated confidence score** is assigned:
        * `0.95` for successfully identified known intents.
        * `0.2` for "unknown" intents returned by Gemini.
        * `0.0` if `json.loads` fails (malformed JSON response).
    * The final NLU output structure (`{"intent": {...}, "entities": {...}, "original_text": str}`) was corrected to ensure `entities` and `original_text` are top-level keys, not nested within `intent`.
    * Corrected the `google.generativeai` SDK call in `process_nlu` to use `config=types.GenerateContentConfig(...)` instead of `generation_config`, resolving a keyword argument error.
    * Defined `UNKNOWN_INTENT_NAME: str = "unknown"` as a class attribute within `GeminiNLUService` to ensure consistent referencing of the unknown intent string.
* **Unit Test Updates:**
    * `services/brain/language_center/nlu/tests/test_gemini_nlu_service.py` was updated to **assert the presence, type, and expected value** of the `confidence` score for both known and "unknown" intent scenarios.
    * New test cases were added to verify confidence scores and structured outputs for edge cases like JSON decoding errors and empty Gemini API responses.
    * Assertions were added to confirm the `google.generativeai` API call correctly passes `config` arguments (`response_mime_type` and `temperature`).
* **Code Quality Improvements:**
    * Refactored `services/action_executor/tests/test_action_executor.py` and `services/brain/language_center/nlg/tests/test_gemini_nlg_service.py` to address **Ruff E501 (line too long) violations** by breaking long lines in comments and string literals.
    * Addressed **MyPy `attr-defined` errors** in test mocks by using `cast(Any, ...)` where mock attributes like `return_value` and `side_effect` are accessed, and corrected `Generator` return type hints for `pytest` fixtures.
    * Ensured all functions and modules in test files have appropriate **docstrings** (`D100`, `D103`, `D401`, `D205`) as required by Ruff.

---

## 🧪 How to Test

Please provide detailed steps for reviewers to test your changes. Include any special setup or commands needed.

1.  **Ensure all dependencies are installed** and your `GOOGLE_API_KEY` is set in your environment (e.g., in a `.env` file).
2.  **Ensure `pre-commit` hooks are installed** (if not already):
    ```bash
    pre-commit install
    ```
3.  **Run all pre-commit checks** to verify code quality and type correctness:
    ```bash
    pre-commit run --all-files
    ```
    * Expected result: All hooks (`ruff`, `ruff-format`, `pytest`, `mypy`) should **Pass**.
4.  **Run unit tests** to confirm functionality:
    ```bash
    pytest
    ```
    * Expected result: All 30 tests should **Pass**.
5.  **Perform a smoke test** to observe confidence scores in action:
    ```bash
    python main.py
    ```
    * **Input 1:** `Hello Viki!`
        * Expected output (`--- Viki's NLU Analysis ---` section):
            ```
            Intent: {'name': 'greet', 'confidence': 0.95}
            Entities: {}
            ```
    * **Input 2:** `What time is it in Tokyo?`
        * Expected output:
            ```
            Intent: {'name': 'get_time', 'confidence': 0.95}
            Entities: {'location': 'Tokyo'}
            ```
    * **Input 3:** `Random words that make no sense.`
        * Expected output:
            ```
            Intent: {'name': 'unknown', 'confidence': 0.2}
            Entities: {'raw_query': 'Random words that make no sense.'} # Or similar if LLM provides raw_query
            ```
    * Type `exit` or `quit` to end the conversation.

---

## 📸 Screenshots / GIFs (If applicable)

N/A - Changes primarily affect backend logic and code quality, not direct UI.

---

## ✅ Checklist

Please ensure the following points are checked before requesting a review:

-   [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
-   [x] My code follows the project's [code style guidelines](#4-code-style--quality-mandatory).
-   [x] I have run `pre-commit install` and ensured all pre-commit hooks pass.
-   [x] I have added/updated unit tests for my changes.
-   [ ] I have added/updated integration tests if the change involves multiple services.
-   [ ] I have added/updated NLU/NLG test data if applicable.
-   [x] All existing tests pass when run locally.
-   [x] I have updated the documentation (code comments, API docs, user guides) where necessary.
-   [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
-   [x] I have squashed my commits into a single logical commit if applicable.

---

## 🙋‍♀️ Reviewer Suggestions (Optional)

@github_username (e.g., for expertise in a specific component)

---

**Thank you for your contribution!**