### PR TITLE
feat(brain/pre-frontal-cortex): Add conceptual LongTermMemory dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ Gemini API access. This is typically loaded from a .env file.
 import logging
 import sys
 import uuid
+from unittest.mock import MagicMock
 
 import dotenv
 
@@ -92,7 +93,7 @@ def main() -> None:
     # Generate a dummy device ID for this session
     session_device_id = uuid.uuid4()
     # For a single session, we'll use a consistent user_id
-    session_user_id = uuid.uuid4()  ## NEW CODE ##
+    session_user_id = uuid.uuid4()
 
     try:
         # 1. Initialize NLU and NLG services
@@ -117,9 +118,12 @@ def main() -> None:
 
         ## NEW CODE: Initialize ShortTermMemory and PrefrontalCortex ##
         short_term_memory = ShortTermMemory()
+        long_term_memory = MagicMock()
+
         prefrontal_cortex = PrefrontalCortex(
             short_term_memory=short_term_memory,
             action_executor=action_executor,
+            long_term_memory=long_term_memory,
         )
         main_logger.info(
             "ShortTermMemory, ActionExecutor, and PrefrontalCortex initialized."
@@ -147,7 +151,7 @@ def main() -> None:
     # --- Main Interaction Loop ---
     # We'll use the session_device_id as the
     # conversation_id for simplicity in this demo.
-    conversation_id_for_session = session_device_id  ## NEW CODE ##
+    conversation_id_for_session = session_device_id
 
     while True:
         user_input = input("\nYou: ")

--- a/services/brain/pre_forntal_cortex/src/pre_frontal_cortex.py
+++ b/services/brain/pre_forntal_cortex/src/pre_frontal_cortex.py
@@ -26,7 +26,10 @@ class PrefrontalCortex:
     action_executor: ActionExecutor
 
     def __init__(
-        self, short_term_memory: ShortTermMemory, action_executor: ActionExecutor
+        self,
+        short_term_memory: ShortTermMemory,
+        action_executor: ActionExecutor,
+        long_term_memory: Any,
     ) -> None:
         """Initialize the PrefrontalCortex component.
 
@@ -36,6 +39,7 @@ class PrefrontalCortex:
         # --- CORRECTED LINES BELOW ---
         self.short_term_memory = short_term_memory  # Assign the injected instance
         self.action_executor = action_executor  # Assign the injected instance
+        self.long_term_memory = long_term_memory  # Assign the injected instance
         self.logger = logger  # Initialize your logger
         self.low_confidence_threshold = 0.4  # Re-add this threshold
         # --- END CORRECTED LINES ---

--- a/services/brain/pre_forntal_cortex/tests/test_pre_frontal_cortex.py
+++ b/services/brain/pre_forntal_cortex/tests/test_pre_frontal_cortex.py
@@ -13,6 +13,8 @@ from services.brain.short_term_mem.src.short_term_memory import (
     ShortTermMemory,
 )
 
+# We do NOT import LongTermMemory here if the class itself doesn't exist yet.
+
 
 @pytest.fixture
 def prefrontal_cortex_instance() -> PrefrontalCortex:
@@ -20,44 +22,40 @@ def prefrontal_cortex_instance() -> PrefrontalCortex:
     # Create mocks for the required dependencies
     mock_short_term_memory = MagicMock(spec=ShortTermMemory)
     mock_action_executor = MagicMock(spec=ActionExecutor)
+    # Just a simple MagicMock, as the class isn't defined or imported yet.
+    mock_long_term_memory = MagicMock()
 
     # Return a PrefrontalCortex instance initialized with the mocks
     return PrefrontalCortex(
-        short_term_memory=mock_short_term_memory, action_executor=mock_action_executor
+        short_term_memory=mock_short_term_memory,
+        action_executor=mock_action_executor,
+        long_term_memory=mock_long_term_memory,
     )
 
 
-# --- CRITICAL MODIFICATION FOR THIS TEST ---
-# This test verifies that dependencies are *stored*, not *instantiated* by PFC.
-# Therefore, it should NOT use @patch decorators for the dependencies it receives.
-# Remove the @patch decorators from this test function.
-# Rename the function to be more accurate.
 def test_prefrontal_cortex_stores_dependencies():
     """Test that PrefrontalCortex correctly stores its provided dependencies."""
     mock_short_term_memory = MagicMock(spec=ShortTermMemory)
     mock_action_executor = MagicMock(spec=ActionExecutor)
+    mock_long_term_memory = MagicMock()
 
     pfc = PrefrontalCortex(
         short_term_memory=mock_short_term_memory,
         action_executor=mock_action_executor,
+        long_term_memory=mock_long_term_memory,
     )
 
     # Verify that the provided mock instances are stored correctly
     assert pfc.short_term_memory == mock_short_term_memory
     assert pfc.action_executor == mock_action_executor
-
-    # REMOVED: mock_short_term_memory_class.assert_called_once()
-    # REMOVED: mock_action_executor_class.assert_called_once()
-    # These assertions are incorrect for dependency injection.
+    assert pfc.long_term_memory == mock_long_term_memory
 
 
-# --- END CRITICAL MODIFICATION ---
-
-
+# This test is commented out as per your previous version.
 # @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ShortTermMemory")
 # @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ActionExecutor")
 # def test_prefrontal_cortex_initializes_short_term_memory(
-#    mock_action_executor_class: MagicMock,  # <-- Order matters for patched arguments
+#    mock_action_executor_class: MagicMock,
 #    mock_short_term_memory_class: MagicMock,
 # ):
 #    """Test that PrefrontalCortex initializes ShortTermMemory on startup."""
@@ -75,27 +73,29 @@ def test_prefrontal_cortex_stores_dependencies():
 
 @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ShortTermMemory")
 @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ActionExecutor")
+# Removed the @patch for LongTermMemory as it's not needed for this approach
 def test_process_dialogue_turn_loads_and_updates_context(
     mock_action_executor_class: MagicMock,
     mock_short_term_memory_class: MagicMock,
+    # Removed mock_long_term_memory_class from parameters
 ):
     """Test that process_dialogue_turn loads existing context and updates it."""
-    # Setup mock ShortTermMemory instance (this will be the instance
-    # returned by mock_short_term_memory_class)
     mock_short_term_memory_instance = MagicMock(spec=ShortTermMemory)
-    # Configure get_conversation_context to return an existing context
+
     mock_short_term_memory_instance.get_conversation_context.return_value = {
         "user_id": str(uuid4()),
         "interaction_count": 5,
-        "dialogue_state": "IDLE",  # Add initial dialogue state
+        "dialogue_state": "IDLE",
         "existing_data": "value",
     }
-    # Link the mock class to return our mock instance
     mock_short_term_memory_class.return_value = mock_short_term_memory_instance
+
+    mock_long_term_memory_instance = MagicMock()  # Directly create a MagicMock instance
 
     pfc = PrefrontalCortex(
         short_term_memory=mock_short_term_memory_instance,
         action_executor=mock_action_executor_class.return_value,
+        long_term_memory=mock_long_term_memory_instance,
     )
 
     conversation_id = uuid4()
@@ -105,20 +105,17 @@ def test_process_dialogue_turn_loads_and_updates_context(
     nlu_results = {
         "intent": {"name": "greet", "confidence": 0.95},
         "entities": {},
-    }  # Example NLU results
+    }
 
-    # Call the method under test
     response = pfc.process_dialogue_turn(
         turn_id, conversation_id, user_id, processed_text, nlu_results
     )
 
-    # Assertions for ShortTermMemory interactions
     mock_short_term_memory_instance.get_conversation_context.assert_called_once_with(
         conversation_id
     )
     mock_short_term_memory_instance.update_conversation_context.assert_called_once()
 
-    # Get the arguments passed to update_conversation_context
     args, kwargs = mock_short_term_memory_instance.update_conversation_context.call_args
     updated_conv_id = args[0]
     updated_context = args[1]
@@ -127,35 +124,37 @@ def test_process_dialogue_turn_loads_and_updates_context(
     assert updated_context["last_turn_id"] == str(turn_id)
     assert updated_context["last_processed_text"] == processed_text
     assert updated_context["last_nlu_results"] == nlu_results
-    assert updated_context["interaction_count"] == 6  # Incremented from 5
+    assert updated_context["interaction_count"] == 6
     assert updated_context["user_id"] == str(user_id)
-    assert updated_context["existing_data"] == "value"  # Ensure existing data persists
+    assert updated_context["existing_data"] == "value"
     assert "last_active_timestamp" in updated_context
     assert updated_context["dialogue_state"] == "GREETING_INITIATED"
 
-    # Assertions for PrefrontalCortex's own return value
     assert response["success"] is True
     assert "Hello! How can I help you today?" in response["va_response_text"]
-    assert response["action_taken"] is None  # No action_executor call yet in PFC logic
+    assert response["action_taken"] is None
     assert response["new_dialogue_state"] == "GREETING_INITIATED"
 
 
 @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ShortTermMemory")
 @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ActionExecutor")
+# Removed the @patch for LongTermMemory
 def test_process_dialogue_turn_creates_new_context(
     mock_action_executor_class: MagicMock,
     mock_short_term_memory_class: MagicMock,
+    # Removed mock_long_term_memory_class from parameters
 ):
     """Test that process_dialogue_turn creates a new context if none exists."""
     mock_short_term_memory_instance = MagicMock(spec=ShortTermMemory)
-    # Configure get_conversation_context to return None (no existing context)
     mock_short_term_memory_instance.get_conversation_context.return_value = None
     mock_short_term_memory_class.return_value = mock_short_term_memory_instance
 
-    # MODIFIED: Instantiate PrefrontalCortex with the mocked dependencies
+    mock_long_term_memory_instance = MagicMock()  # Directly create a MagicMock instance
+
     pfc = PrefrontalCortex(
         short_term_memory=mock_short_term_memory_instance,
         action_executor=mock_action_executor_class.return_value,
+        long_term_memory=mock_long_term_memory_instance,
     )
 
     conversation_id = uuid4()
@@ -200,9 +199,11 @@ def test_process_dialogue_turn_creates_new_context(
 
 @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ShortTermMemory")
 @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ActionExecutor")
+# Removed the @patch for LongTermMemory
 def test_process_dialogue_turn_handles_greeting_intent(
     mock_action_executor_class: MagicMock,
     mock_short_term_memory_class: MagicMock,
+    # Removed mock_long_term_memory_class from parameters
 ):
     """Test that PFC correctly responds to a greeting intent."""
     mock_short_term_memory_instance = MagicMock(spec=ShortTermMemory)
@@ -213,10 +214,12 @@ def test_process_dialogue_turn_handles_greeting_intent(
     }
     mock_short_term_memory_class.return_value = mock_short_term_memory_instance
 
-    # MODIFIED: Instantiate PrefrontalCortex with the mocked dependencies
+    mock_long_term_memory_instance = MagicMock()  # Directly create a MagicMock instance
+
     pfc = PrefrontalCortex(
         short_term_memory=mock_short_term_memory_instance,
         action_executor=mock_action_executor_class.return_value,
+        long_term_memory=mock_long_term_memory_instance,
     )
 
     nlu_results = {"intent": {"name": "greet", "confidence": 0.95}, "entities": {}}
@@ -230,7 +233,6 @@ def test_process_dialogue_turn_handles_greeting_intent(
     assert response["action_taken"] is None
     assert response["new_dialogue_state"] == "GREETING_INITIATED"
 
-    # Verify context update
     args, kwargs = mock_short_term_memory_instance.update_conversation_context.call_args
     updated_context = args[1]
     assert updated_context["dialogue_state"] == "GREETING_INITIATED"
@@ -239,9 +241,11 @@ def test_process_dialogue_turn_handles_greeting_intent(
 
 @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ShortTermMemory")
 @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ActionExecutor")
+# Removed the @patch for LongTermMemory
 def test_process_dialogue_turn_handles_low_confidence_intent(
     mock_action_executor_class: MagicMock,
     mock_short_term_memory_class: MagicMock,
+    # Removed mock_long_term_memory_class from parameters
 ):
     """Test that PFC correctly responds to a low confidence intent."""
     mock_short_term_memory_instance = MagicMock(spec=ShortTermMemory)
@@ -252,13 +256,14 @@ def test_process_dialogue_turn_handles_low_confidence_intent(
     }
     mock_short_term_memory_class.return_value = mock_short_term_memory_instance
 
-    # MODIFIED: Instantiate PrefrontalCortex with the mocked dependencies
+    mock_long_term_memory_instance = MagicMock()  # Directly create a MagicMock instance
+
     pfc = PrefrontalCortex(
         short_term_memory=mock_short_term_memory_instance,
         action_executor=mock_action_executor_class.return_value,
+        long_term_memory=mock_long_term_memory_instance,
     )
 
-    # NLU results with low confidence
     nlu_results = {
         "intent": {"name": "unclear_intent", "confidence": 0.3},
         "entities": {},
@@ -275,7 +280,6 @@ def test_process_dialogue_turn_handles_low_confidence_intent(
     assert response["action_taken"] is None
     assert response["new_dialogue_state"] == "ASKING_CLARIFICATION"
 
-    # Verify context update
     args, kwargs = mock_short_term_memory_instance.update_conversation_context.call_args
     updated_context = args[1]
     assert updated_context["dialogue_state"] == "ASKING_CLARIFICATION"
@@ -283,12 +287,12 @@ def test_process_dialogue_turn_handles_low_confidence_intent(
 
 
 @patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ShortTermMemory")
-@patch(
-    "services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ActionExecutor"
-)  # <-- NEW PATCH
+@patch("services.brain.pre_forntal_cortex.src.pre_frontal_cortex.ActionExecutor")
+# Removed the @patch for LongTermMemory
 def test_process_dialogue_turn_handles_default_unhandled_intent(
-    mock_action_executor_class: MagicMock,  # <-- Order matters for patched arguments
+    mock_action_executor_class: MagicMock,
     mock_short_term_memory_class: MagicMock,
+    # Removed mock_long_term_memory_class from parameters
 ):
     """Test that PFC handles an unhandled intent with a default response."""
     mock_short_term_memory_instance = MagicMock(spec=ShortTermMemory)
@@ -299,13 +303,14 @@ def test_process_dialogue_turn_handles_default_unhandled_intent(
     }
     mock_short_term_memory_class.return_value = mock_short_term_memory_instance
 
-    # MODIFIED: Instantiate PrefrontalCortex with the mocked dependencies
+    mock_long_term_memory_instance = MagicMock()  # Directly create a MagicMock instance
+
     pfc = PrefrontalCortex(
         short_term_memory=mock_short_term_memory_instance,
         action_executor=mock_action_executor_class.return_value,
+        long_term_memory=mock_long_term_memory_instance,
     )
 
-    # NLU results with a confidence above low threshold but not matching 'greeting'
     nlu_results = {
         "intent": {"name": "unknown_topic", "confidence": 0.6},
         "entities": {},
@@ -323,7 +328,6 @@ def test_process_dialogue_turn_handles_default_unhandled_intent(
     assert response["action_taken"] is None
     assert response["new_dialogue_state"] == "IDLE"
 
-    # Verify context update
     args, kwargs = mock_short_term_memory_instance.update_conversation_context.call_args
     updated_context = args[1]
     assert updated_context["dialogue_state"] == "IDLE"


### PR DESCRIPTION
Prepares the PrefrontalCortex for future integration with the LongTermMemory component.

This commit:
- Modifies `PrefrontalCortex.__init__` to accept `long_term_memory` as a dependency.
- Stores the injected `long_term_memory` instance (using `typing.Any` as a placeholder type hint for now).
- Updates all relevant unit tests for `PrefrontalCortex` to provide a mock `LongTermMemory` instance during instantiation, ensuring all tests continue to pass.

This architectural change establishes the necessary hook for Viki to leverage long-term memory in subsequent features.

---
name: Code Contribution
about: Propose a change to the codebase (feature, bugfix, refactor)
title: 'feat(brain/pre-frontal-cortex): Add conceptual LongTermMemory dependency'
labels: 'enhancement, architectural'
assignees: '' 

---

## ✨ Type of Change

Please check the type of change your PR introduces:

- [x] New feature
- [ ] Bug fix
- [ ] Refactor/Code cleanup
- [ ] Documentation update
- [ ] Build/CI/CD related change
- [ ] Chore (e.g., dependency updates, configs)
- [ ] Other (please describe below)

## 📝 Description

This PR introduces a crucial architectural update to the **`PrefrontalCortex`** component, preparing it for future integration with the **`LongTermMemory`** capabilities. The `__init__` method of the `PrefrontalCortex` now accepts and stores a `long_term_memory` instance as a dependency.

This change is purely conceptual and foundational; no actual calls to `long_term_memory` methods or complex logic have been added at this stage. It ensures that `PrefrontalCortex` is "conceptually ready" to interact with `LongTermMemory` when that component is fully implemented.

## 🔗 Related Issues

Link to the GitHub issue(s) this PR addresses. Use keywords like `Closes #`, `Fixes #`, or `Resolves #` to automatically close the issue(s) when the PR is merged.

- N/A (Internal enabler task)
# - Closes #40 
# - Resolves #40

## 💡 Changes Made

* Modified the `PrefrontalCortex` class's `__init__` method to accept a `long_term_memory` parameter.
* The `PrefrontalCortex` now stores this injected instance as `self.long_term_memory`.
* Updated all existing unit tests for `PrefrontalCortex` (in `services/brain/pre_forntal_cortex/tests/test_pre_frontal_cortex.py`) to pass a `MagicMock` instance for `LongTermMemory` during instantiation.
* Ensured all `PrefrontalCortex` unit tests continue to pass with this change.
* No new dependencies were added outside of standard Python `unittest.mock.MagicMock`.
* No breaking changes were introduced.

## 🧪 How to Test

Reviewers can verify this change by running the unit tests for the `PrefrontalCortex` module.

1.  **Navigate to the project root:**
    ```bash
    cd /path/to/viki-va
    ```
2.  **Run the pytest suite (or specifically the PrefrontalCortex tests):**
    ```bash
    pytest services/brain/pre_forntal_cortex/tests/test_pre_frontal_cortex.py
    ```
3.  **Expected result/behavior:** All tests within `test_pre_frontal_cortex.py` should pass, indicating that the dependency injection is correctly handled without regressions.

## 📸 Screenshots / GIFs (If applicable)

N/A - This change is purely architectural and does not involve UI or visual elements.

## ✅ Checklist

Please ensure the following points are checked before requesting a review:

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guide.
- [x] My code follows the project's [code style guidelines](#4-code-style--quality-mandatory).
- [x] I have run `pre-commit install` and ensured all pre-commit hooks pass.
- [x] I have added/updated unit tests for my changes.
- [ ] I have added/updated integration tests if the change involves multiple services.
- [ ] I have added/updated NLU/NLG test data if applicable.
- [x] All existing tests pass when run locally.
- [x] I have updated the documentation (code comments, API docs, user guides) where necessary.
- [x] My commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) standard.
- [x] I have squashed my commits into a single logical commit if applicable.

---

## 🙋‍♀️ Reviewer Suggestions (Optional)

@AppCarver 

---

**Thank you for your contribution!**